### PR TITLE
Remove redis external port binding

### DIFF
--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -57,8 +57,6 @@ services:
     volumes:
     - ./packages:/root/hubot/packages
     - ./scripts:/root/hubot/scripts
-    ports:
-    - "9229:9229"
   redis:
     image: wissoft/redis:5.0-amd64
     networks:


### PR DESCRIPTION
Because of security issues we shouldn't use it in production